### PR TITLE
Middleware not picked up with django 3.6.3

### DIFF
--- a/django_pdb/management/commands/runserver.py
+++ b/django_pdb/management/commands/runserver.py
@@ -55,9 +55,9 @@ class Command(RunServerCommand):
         ipdb_option = options.pop('ipdb')
 
         pdb_middleware = 'django_pdb.middleware.PdbMiddleware'
-        middleware = (settings.MIDDLEWARE
-                      if hasattr(settings, 'MIDDLEWARE')
-                      else settings.MIDDLEWARE_CLASSES)
+        middleware = getattr(settings, 'MIDDLEWARE', None)
+        if middleware is None:
+            middleware = settings.MIDDLEWARE_CLASSES
         if ((pdb_option or settings.DEBUG)
             and pdb_middleware not in middleware):
             middleware += (pdb_middleware,)


### PR DESCRIPTION
From @chayim

Had an issue where middleware wasn't honoured in django 3.6.3.  Stock install from pypi fails with the error below. This fixes that.

Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django/core/management/commands/runserver.py", line 62, in execute
    super(Command, self).execute(*args, **options)
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/chayim/.venvs/python/3.6.3.siemphony.core.master/lib/python3.6/site-packages/django_pdb/management/commands/runserver.py", line 62, in handle
    if middlware is None: